### PR TITLE
Fix: Resolve RefreshIndicator type error and previous enhancements

### DIFF
--- a/lib/screens/admin_products_screen.dart
+++ b/lib/screens/admin_products_screen.dart
@@ -103,7 +103,7 @@ class _AdminProductsScreenState extends State<AdminProductsScreen> {
                 setState(() {
                   _categoriesFuture = _fetchCategories();
                 });
-                return _categoriesFuture;
+                await _categoriesFuture; // Await the completion of the new future
               },
               child: FutureBuilder<List<Category>>(
                 future: _categoriesFuture,


### PR DESCRIPTION
This commit addresses a build error in AdminProductsScreen related to the RefreshIndicator's onRefresh callback expecting Future<void> but receiving Future<List<Category>>?. The onRefresh callback has been corrected to await the future, implicitly returning void.

This commit also includes the previous set of enhancements:

- Refactor: Optimizations and code cleanup based on your feedback
    - Eliminated redundant Firestore subscriptions for UI updates in VehicleListItem and ManagerVehicleDetailScreen, using local timers (Stream.periodic) for live cost updates.
    - Optimized logic for displaying empty lists and search results in ManagerVehiclesListScreen and ManagerHistoryScreen.
    - Refactored common code:
        - Created and integrated TimeCostCalculator utility.
        - Further decomposed UI methods in ManagerVehicleDetailScreen.
    - Optimized data loading in AdminProductsScreen by switching to FutureBuilder and RefreshIndicator.
    - Implemented basic pagination (.limit()) in ManagerVehiclesListScreen and ManagerHistoryScreen.
    - Updated/added tests for TimeCostCalculator and AdminProductsScreen.