### PR TITLE
Fix: Hide 'Complete' button for non-active vehicles in details screen

### DIFF
--- a/lib/screens/manager_vehicle_detail_screen.dart
+++ b/lib/screens/manager_vehicle_detail_screen.dart
@@ -284,6 +284,9 @@ class _ManagerVehicleDetailScreenState extends State<ManagerVehicleDetailScreen>
 
   // Helper method for Complete Button
   Widget _buildCompleteButton(Vehicle vehicle, double pricePerMinute, BuildContext context) {
+    if (vehicle.status != VehicleStatuses.active) {
+      return const SizedBox.shrink(); // Don't show button if not active
+    }
     return ElevatedButton(
       onPressed: () async {
         try {


### PR DESCRIPTION
The 'ЗАВЕРШИТЬ' (Complete) button in ManagerVehicleDetailScreen will now only be displayed if the vehicle's status is 'active'. This prevents an illogical UI state where a completed service, viewed from history, could seemingly be completed again.

This commit finalizes the series of fixes and enhancements based on recent feedback from you, including Firestore index requirements (to be applied by you), build error fixes, and manager data filtering.